### PR TITLE
add missing include for QRectF in dp.h

### DIFF
--- a/libkoviz/dp.h
+++ b/libkoviz/dp.h
@@ -11,6 +11,7 @@
 #include <QFileInfo>
 #include <QRegExp>
 #include <QHash>
+#include <QRectF>
 #include <stdexcept>
 #include <float.h>
 #include <limits.h>


### PR DESCRIPTION
Addresses issue #5 

Koviz builds and runs on macOS 