### PR TITLE
Updated real-time for Trick not being ran.

### DIFF
--- a/koviz/main.cpp
+++ b/koviz/main.cpp
@@ -666,6 +666,10 @@ int main(int argc, char *argv[])
                                     "the -start/stop options are ignored\n");
                 }
                 VersionNumber version = TrickVersion(run).versionNumber();
+                if ( version == VersionNumber("0.0.0-0") ) {
+                    fprintf(stderr, "koviz [error]: Invalid RUN specified.\n");
+                    exit (-1);
+                }
                 if ( version < VersionNumber("17.0.0-0") ) {
                     fprintf(stderr, "koviz [error]: The -rt realtime option "
                             "requires Trick version 17.0.0+.\n");


### PR DESCRIPTION
Updated a case where if a user has not run the Trick simulation, koviz will not specify that Trick is outdated. Used to see that version 0.0.0-0 was less than 17.0.0-0 and called it outdated, now it sees 0.0.0-0 and realized that Trick wasn't run.